### PR TITLE
some neovim plugin fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ flake.nix
 flake.lock
 result*
 .envrc
+.luarc.json

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,7 @@
+ignore = {
+  "631",    -- max_line_length
+  "122",    -- read-only field of global variable
+}
+read_globals = {
+  "vim",
+}

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferSingle"
+call_parentheses = "NoSingleTable"
+collapse_simple_statement = "Never"

--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -37,10 +37,7 @@ if not vim.g.loaded_rustowl then
 
   local function rustowl_user_cmd(opts)
     if vim.bo[0].filetype ~= 'rust' then
-      vim.notify(
-        'Rustowl: Current buffer is not a rust file.',
-        vim.log.levels.ERROR
-      )
+      vim.notify('Rustowl: Current buffer is not a rust file.', vim.log.levels.ERROR)
       return
     end
     local fargs = opts.fargs

--- a/lua/rustowl/config.lua
+++ b/lua/rustowl/config.lua
@@ -1,6 +1,6 @@
 ---NOTE: `require`ing this module initializes the config
 
----@class rustowl.Config: vim.lsp.ClientConfig
+---@class rustowl.Config
 ---
 ---Whether to auto-attach the LSP client when opening a Rust file.
 ---Default: `true`
@@ -11,6 +11,9 @@
 ---
 ---Time in milliseconds to hover with the cursor before triggering RustOwl
 ---@field idle_time? number
+---
+---The LSP client config (This can also be set using |vim.lsp.config()|).
+---@field client? rustowl.ClientConfig
 
 ---NOTE: This allows lua-language-server to provide users
 ---completions and hover when setting vim.g.rustowl directly.
@@ -18,48 +21,53 @@
 ---@type nil | rustowl.Config | fun():rustowl.Config
 vim.g.rustowl = vim.g.rustowl
 
+---@class rustowl.ClientConfig: vim.lsp.ClientConfig
+---
+---A function for determining the root directory
+---@field root_dir? fun():string()?
+
 ---Internal config (defaults), merged with the user config.
 ---@class rustowl.internal.Config
 local default_config = {
-	---@type boolean
-	auto_attach = true,
+  ---@type boolean
+  auto_attach = true,
 
-	---@type boolean
-	auto_enable = false,
+  ---@type boolean
+  auto_enable = false,
 
-	---@type number
-	idle_time = 500,
+  ---@type number
+  idle_time = 500,
 
-	---@type vim.lsp.ClientConfig
-	client = {
+  ---@class rustowl.internal.ClientConfig: vim.lsp.ClientConfig
+  client = {
 
-		---@type string[]
-		cmd = { "cargo", "owlsp" },
+    ---@type string[]
+    cmd = { 'cargo', 'owlsp' },
 
-		---@type fun():string?
-		root_dir = function()
-			return vim.fs.dirname(vim.fs.find({ "Cargo.toml", ".git" }, { upward = true })[1])
-		end,
-	},
+    ---@type fun():string?
+    root_dir = function()
+      return vim.fs.root(0, { 'Cargo.toml', '.git' })
+    end,
+  },
 }
 
-local user_config = type(vim.g.rustowl) == "function" and vim.g.rustowl() or vim.g.rustowl or {}
+local user_config = type(vim.g.rustowl) == 'function' and vim.g.rustowl() or vim.g.rustowl or {}
 
 ---@cast user_config rustowl.Config
 
 ---@type rustowl.Config
-local lsp_config = type(vim.lsp.config) == "table" and vim.lsp.config.rustowl or {}
+local lsp_config = type(vim.lsp.config) == 'table' and vim.lsp.config.rustowl or {}
 
 ---@type rustowl.internal.Config
-local config = vim.tbl_deep_extend("force", default_config, user_config, lsp_config)
+local config = vim.tbl_deep_extend('force', default_config, user_config, lsp_config)
 
-vim.validate({
-	auto_attach = { config.auto_attach, "boolean" },
-	auto_enable = { config.auto_enable, "boolean" },
-	idle_time = { config.idle_time, "number" },
-	client = { config.client, { "table" } },
-})
+vim.validate {
+  auto_attach = { config.auto_attach, 'boolean' },
+  auto_enable = { config.auto_enable, 'boolean' },
+  idle_time = { config.idle_time, 'number' },
+  client = { config.client, { 'table' } },
+}
 
-config.client.name = "rustowl"
+config.client.name = 'rustowl'
 
 return config

--- a/lua/rustowl/highlight.lua
+++ b/lua/rustowl/highlight.lua
@@ -1,36 +1,36 @@
 local M = {}
 
-local hl_ns = vim.api.nvim_create_namespace("rustowl")
+local hl_ns = vim.api.nvim_create_namespace('rustowl')
 
 ---@param line number
 ---@param col number
 ---@param bufnr? number
 function M.enable(line, col, bufnr)
-	local lsp = require("rustowl.lsp")
-	bufnr = bufnr or vim.api.nvim_get_current_buf()
-	local clients = lsp.get_rustowl_clients({ bufnr = bufnr })
-	local params = {
-		position = { line = line - 1, character = col },
-		document = vim.lsp.util.make_text_document_params(),
-	}
+  local lsp = require('rustowl.lsp')
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  local clients = lsp.get_rustowl_clients { bufnr = bufnr }
+  local params = {
+    position = { line = line - 1, character = col },
+    document = vim.lsp.util.make_text_document_params(),
+  }
 
-	for _, client in ipairs(clients) do
-		client:request("rustowl/cursor", params, function(_, result, _)
-			if result ~= nil then
-				for _, deco in ipairs(result["decorations"]) do
-					local start = { deco["range"]["start"]["line"], deco["range"]["start"]["character"] }
-					local finish = { deco["range"]["end"]["line"], deco["range"]["end"]["character"] }
-					local opts = { regtype = "v", inclusive = true }
-					vim.highlight.range(bufnr, hl_ns, deco["type"], start, finish, opts)
-				end
-			end
-		end, bufnr)
-	end
+  for _, client in ipairs(clients) do
+    client:request('rustowl/cursor', params, function(_, result, _)
+      if result ~= nil then
+        for _, deco in ipairs(result['decorations']) do
+          local start = { deco['range']['start']['line'], deco['range']['start']['character'] }
+          local finish = { deco['range']['end']['line'], deco['range']['end']['character'] }
+          local opts = { regtype = 'v', inclusive = true }
+          vim.highlight.range(bufnr, hl_ns, deco['type'], start, finish, opts)
+        end
+      end
+    end, bufnr)
+  end
 end
 
 ---@param bufnr? number
 function M.disable(bufnr)
-	vim.api.nvim_buf_clear_namespace(bufnr or 0, hl_ns, 0, -1)
+  vim.api.nvim_buf_clear_namespace(bufnr or 0, hl_ns, 0, -1)
 end
 
 return M

--- a/lua/rustowl/init.lua
+++ b/lua/rustowl/init.lua
@@ -3,29 +3,29 @@ local M = {}
 --- Enable RustOwl highlighting
 ---@param bufnr? number
 M.enable = function(bufnr)
-	require("rustowl.show-on-hover").enable(bufnr)
+  require('rustowl.show-on-hover').enable(bufnr)
 end
 
 --- Disable RustOwl highlighting
 ---@param bufnr? number
 M.disable = function(bufnr)
-	require("rustowl.show-on-hover").disable(bufnr)
+  require('rustowl.show-on-hover').disable(bufnr)
 end
 
 --- Toggle RustOwl highlighting on or off
 ---@param bufnr? number
 M.toggle = function(bufnr)
-	require("rustowl.show-on-hover").toggle(bufnr)
+  require('rustowl.show-on-hover').toggle(bufnr)
 end
 
 ---@return true if rustowl highlighting is enabled
 M.is_enabled = function()
-	return require("rustowl.show-on-hover").is_enabled()
+  return require('rustowl.show-on-hover').is_enabled()
 end
 
 ---@param opts? rustowl.Config
 function M.setup(opts)
-	vim.g.rustowl = opts
+  vim.g.rustowl = opts
 end
 
 return M

--- a/lua/rustowl/lsp.lua
+++ b/lua/rustowl/lsp.lua
@@ -6,14 +6,18 @@ M.get_rustowl_clients = function(filter)
   filter = vim.tbl_deep_extend('force', filter or {}, {
     name = 'rustowl',
   })
-  return vim.lsp.get_clients(filter)
+  ---@diagnostic disable-next-line: deprecated
+  return type(vim.lsp.get_clients) == 'function' and vim.lsp.get_clients(filter) or vim.lsp.get_active_clients(filter)
 end
 
 ---Start / attach the LSP client
 ---@return integer|nil client_id The LSP client ID
 M.start = function()
   local config = require('rustowl.config')
-  return vim.lsp.start(config.client)
+  local root_dir = config.client.root_dir()
+  ---@type vim.lsp.ClientConfig
+  local client_config = vim.tbl_deep_extend('force', config.client, { root_dir = root_dir })
+  return vim.lsp.start(client_config)
 end
 
 ---Compatibility for a breaking change in Nvim 0.11

--- a/lua/rustowl/lsp.lua
+++ b/lua/rustowl/lsp.lua
@@ -10,13 +10,91 @@ M.get_rustowl_clients = function(filter)
   return type(vim.lsp.get_clients) == 'function' and vim.lsp.get_clients(filter) or vim.lsp.get_active_clients(filter)
 end
 
+---@param client vim.lsp.Client
+---@param root_dir string
+---@return boolean
+local function is_in_workspace(client, root_dir)
+  if not client.workspace_folders then
+    return false
+  end
+  for _, dir in ipairs(client.workspace_folders) do
+    if (root_dir .. '/'):sub(1, #dir.name + 1) == dir.name .. '/' then
+      return true
+    end
+  end
+  return false
+end
+
+---Compatibility for a breaking change in Nvim 0.11
+--- @param client vim.lsp.Client
+--- @param method string LSP method name.
+--- @param params table? LSP request params.
+--- @return boolean status indicating if the notification was successful.
+---                        If it is false, then the client has shutdown.
+local function client_notify(client, method, params)
+  local info = debug.getinfo(client.notify, 'u')
+  if info.nparams > 0 then
+    ---@diagnostic disable-next-line: param-type-mismatch
+    return client:notify(method, params)
+  else
+    ---@diagnostic disable-next-line: param-type-mismatch
+    return client.notify(method, params)
+  end
+end
+
+---@param client vim.lsp.Client
+---@param root_dir string
+local function notify_workspace_folder(client, root_dir)
+  if is_in_workspace(client, root_dir) then
+    return
+  end
+  local workspace_folder = { uri = vim.uri_from_fname(root_dir), name = root_dir }
+  local params = {
+    event = {
+      added = { workspace_folder },
+      removed = {},
+    },
+  }
+  client_notify(client, 'workspace/didChangeWorkspaceFolders', params)
+  if not client.workspace_folders then
+    client.workspace_folders = {}
+  end
+  table.insert(client.workspace_folders, workspace_folder)
+end
+
 ---Start / attach the LSP client
 ---@return integer|nil client_id The LSP client ID
 M.start = function()
   local config = require('rustowl.config')
   local root_dir = config.client.root_dir()
+  if not root_dir then
+    vim.schedule(function()
+      vim.notify('rustowl: Failed to detect root_dir.', vim.log.levels.ERROR)
+    end)
+    return
+  end
+
+  for _, client in ipairs(M.get_rustowl_clients()) do
+    if not is_in_workspace(client, root_dir) then
+      -- Attach to existing session
+      notify_workspace_folder(client, root_dir)
+      vim.lsp.buf_attach_client(0, client.id)
+      return
+    end
+  end
+
+  ---@param client vim.lsp.Client
+  local notify_workspace_folder_hook = function(client)
+    notify_workspace_folder(client, root_dir)
+  end
+  local on_init = type(config.client.on_init) == 'function'
+      and function(...)
+        notify_workspace_folder_hook(...)
+        config.client.on_init(...)
+      end
+    or notify_workspace_folder_hook
   ---@type vim.lsp.ClientConfig
-  local client_config = vim.tbl_deep_extend('force', config.client, { root_dir = root_dir })
+  local client_config = vim.tbl_deep_extend('force', config.client, { root_dir = root_dir, on_init = on_init })
   return vim.lsp.start(client_config)
 end
 

--- a/lua/rustowl/lsp.lua
+++ b/lua/rustowl/lsp.lua
@@ -29,8 +29,7 @@ end
 --- @param client vim.lsp.Client
 --- @param method string LSP method name.
 --- @param params table? LSP request params.
---- @return boolean status indicating if the notification was successful.
----                        If it is false, then the client has shutdown.
+--- @return boolean status indicating if the notification was successful. If it is false, then the client has shutdown.
 local function client_notify(client, method, params)
   local info = debug.getinfo(client.notify, 'u')
   if info.nparams > 0 then

--- a/lua/rustowl/show-on-hover.lua
+++ b/lua/rustowl/show-on-hover.lua
@@ -44,10 +44,14 @@ function M.enable(bufnr)
     timer = t
     assert(timer, err)
 
-    timer:start(idle_time_ms, 0, vim.schedule_wrap(function()
-      local line, col = unpack(vim.api.nvim_win_get_cursor(0))
-      require('rustowl.highlight').enable(line, col, bufnr)
-    end))
+    timer:start(
+      idle_time_ms,
+      0,
+      vim.schedule_wrap(function()
+        local line, col = unpack(vim.api.nvim_win_get_cursor(0))
+        require('rustowl.highlight').enable(line, col, bufnr)
+      end)
+    )
   end
 
   state.augroup = vim.api.nvim_create_augroup('RustOwl', { clear = true })


### PR DESCRIPTION
@mawkler this PR adds some fixes to my previous one:

- Add `.stylua.toml` (for consistent formatting - I notices some things were off) and `.luacheckrc`
- Use `vim.fs.root` for root directory detection (Does the same thing, but is more readable)
- Fix `root_dir` passed to `vim.lsp.start` (The previous commit was passing a function, not a string). 
  This Could be what was causing the issue for you.
  It was definitely a bug (one that I had fixed on my other machine, but apparently didn't push)
  With my nix rustowl build, I still get empty decorations. But maybe it will work now on your end?

Let me know if it doesn't, then I'll investigate further.
If it doesn't work, could you please post the output of `:lua =vim.lsp.get_clients({ name = "rustowl" })[1]` for your working configuration? Maybe I can diff the outputs and see if I'm missing something.  